### PR TITLE
exit with error message on failure to mmap V4L device

### DIFF
--- a/source_v4l.cpp
+++ b/source_v4l.cpp
@@ -267,6 +267,9 @@ source_v4l::source_v4l(const std::string & id, const std::string & descr, const 
 
 	unmap_size = buf.length;
 	io_buffer = static_cast<uint8_t *>(mmap(NULL, buf.length, PROT_READ | PROT_WRITE, MAP_SHARED, fd, buf.m.offset));
+	if (io_buffer == (uint8_t*)-1)
+		error_exit(false, "Failed to map memory for device %s (check LD_PRELOAD, see README.md)",
+					dev.c_str());
 
 	vw = width;
 	vh = height;


### PR DESCRIPTION
Whem mmap() fails it returns -1 (0xfffff...).
This later becomes a SEGFAULT when trying to memcpy this address.
Detect the failure early on an exit with (hopefully) helpful message.

This can happen if the LD_PRELOAD pointing to the V4L shared object
is required but missing (can happen e.g. when loading with empty environment
under systemd).w